### PR TITLE
Add overall "Change status" options

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -13,6 +13,11 @@ Please delete options that are not relevant.
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
+## Change status
+- [ ] Complete, tested, ready to review and merge
+- [ ] Complete, but not tested (may need new tests)
+- [ ] Incomplete/work-in-progress, PR is for discussion/feedback
+
 # How Has This Been Tested?
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


### PR DESCRIPTION
# Description

Adds a new subsection to the "type of change" section, where the change status (complete+tested, complete+untested, or incomplete) can be selected.

Fixes # (issue) NA

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

NA (documentation).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- NA I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- NA I have added tests that prove my fix is effective or that my feature works
- NA New and existing unit tests pass locally with my changes
